### PR TITLE
Convert access to responseHeaders with correct camelCase

### DIFF
--- a/src/responseHandlers/TestResponseHandler.js
+++ b/src/responseHandlers/TestResponseHandler.js
@@ -96,6 +96,11 @@ var TestResponseHandler = jsface.Class(AbstractResponseHandler, {
 
         testCases = sweet + 'String.prototype.has = function(value){ return this.indexOf(value) > -1};' + setEnvHack + testCases;
 
+        /* Convert access to responseHeaders with correct camelCase */
+        testCases = testCases.replace(/responseHeaders\s*\[\s*['"](.*?)['"]\]/gmi, function(matchAll, headerName) {
+            return 'responseHeaders[\'' + Helpers.toHeaderCase(headerName.toLowerCase()) + '\']';
+        });
+
         try {
             vm.runInNewContext(testCases, sandbox);
         } catch (err) {


### PR DESCRIPTION
Convert access to responseHeaders with correct camelCase for custom header name