### PR TITLE
Updated `package.json` to better hold on to specific versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,28 @@
   "bugs": "https://github.com/a85/Newman/issues",
   "description": "Command-line utility for Postman",
   "repository": {
-	  "type": "git",
-	  "url": "git://github.com/a85/Newman.git"
+    "type": "git",
+    "url": "git://github.com/a85/Newman.git"
   },
   "contributors": [
-    {"name": "Prakhar Srivastav", "email": "prakhar1989@gmail.com", "url": "http://prakhar.me"},
-    {"name": "Arjun Variar", "email": "accioarjun@gmail.com", "url": "http://github.com/viig99"},
-    {"name": "Abhijit Kane", "email": "abhijitkane@gmail.com", "url": "http://github.com/abhijitkane"}
+    {
+      "name": "Prakhar Srivastav",
+      "email": "prakhar1989@gmail.com",
+      "url": "http://prakhar.me"
+    },
+    {
+      "name": "Arjun Variar",
+      "email": "accioarjun@gmail.com",
+      "url": "http://github.com/viig99"
+    },
+    {
+      "name": "Abhijit Kane",
+      "email": "abhijitkane@gmail.com",
+      "url": "http://github.com/abhijitkane"
+    }
   ],
-  "engines" : { 
-	  "node" : ">=0.6.x" 
+  "engines": {
+    "node": ">=0.6.x"
   },
   "keywords": [
     "postman",
@@ -25,30 +37,30 @@
     "rest"
   ],
   "bin": {
-	 "newman": "./bin/newman"
+    "newman": "./bin/newman"
   },
   "preferGlobal": true,
   "dependencies": {
-    "cli-color": "0.2.x",
-    "json5": "*",
-    "commander": "2.x.x",
-    "underscore": "1.x.x",
-    "jsface": "2.2.x",
-    "request": "2.40.0",
-    "unirest": "*",
-    "postman_validator" : "0.0.4",
-    "node-uuid" : "1.4.1",
-    "jsdom": "*",
-    "jquery": "2.1.1",
-    "backbone": "*",
-    "lodash": "*",
-    "xml2js": "*",
-    "sugar" : "1.3.9",
-    "tv4": "*",
-    "mkdirp": "*",
     "atob": "1.1.2",
+    "backbone": "^1.1.2",
     "btoa": "1.1.2",
-    "dot": "1.0.3"
+    "cli-color": "0.2.x",
+    "commander": "2.x.x",
+    "dot": "1.0.3",
+    "jquery": "2.1.1",
+    "jsdom": "3.x.x",
+    "jsface": "2.2.x",
+    "json5": "^0.4.0",
+    "lodash": "^3.3.0",
+    "mkdirp": "^0.5.0",
+    "node-uuid": "1.4.1",
+    "postman_validator": "0.0.4",
+    "request": "2.40.0",
+    "sugar": "1.3.9",
+    "tv4": "^1.1.9",
+    "underscore": "1.x.x",
+    "unirest": "^0.4.0",
+    "xml2js": "^0.4.5"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
This PR consists changes to `package.json`
- all dependencies marked with `"*"` have been made to refer to the latest results of `npm install --save`
- forced `jsdom` dependency to `3.x.x`

The PR fixes issue with `jsdom 4` not supporting node in favour of io.js

> From jsdom package: "Note that as of our 4.0.0 release, jsdom no longer works with Node.js™, and instead requires io.js. You are still welcome to install a release in the 3.x series if you are stuck on legacy technology like Node.js™." ~ https://www.npmjs.com/package/jsdom

Otherwise, `jsdom@4.x` is resulting the following error:

```terminal
$ node --version
v0.10.26
$ npm --version
1.4.3

# -----------------------------------------------------------------------------------
# ... after npm install
# -----------------------------------------------------------------------------------

newman@1.2.12 node_modules/newman
├── commander@2.6.0
├── atob@1.1.2
├── btoa@1.1.2
├── node-uuid@1.4.1
├── tv4@1.1.9
├── underscore@1.8.2
├── backbone@1.1.2
├── dot@1.0.3
├── mkdirp@0.5.0 (minimist@0.0.8)
├── jsface@2.2.0
├── json5@0.4.0
├── sugar@1.3.9
├── jquery@2.1.1
├── lodash@3.3.0
├── request@2.40.0 (json-stringify-safe@5.0.0, forever-agent@0.5.2, aws-sign2@0.5.0, oauth-sign@0.3.0, stringstream@0.0.4, tunnel-agent@0.4.0, qs@1.0.2, mime-types@1.0.2, form-data@0.1.4, tough-cookie@0.12.1, http-signature@0.10.1, hawk@1.1.1)
├── unirest@0.4.0 (mime@1.2.11, form-data@0.2.0, request@2.51.0)
├── xml2js@0.4.5 (xmlbuilder@2.6.1, sax@0.6.1)
├── cli-color@0.2.3 (memoizee@0.2.6, es5-ext@0.9.2)
├── postman_validator@0.0.4 (JSV@4.0.2)
└── jsdom@4.0.0 (acorn-globals@1.0.2, xmlhttprequest@1.7.0, xml-name-validator@1.0.0, browser-request@0.3.3, cssom@0.3.0, nwmatcher@1.3.4, parse5@1.4.0, htmlparser2@3.8.2, escodegen@1.6.1, cssstyle@0.2.23, acorn@0.11.0, request@2.53.0)


# --------------------------------------------------------------------------------------------
# ... on usage ...
# --------------------------------------------------------------------------------------------

/node_modules/newman/node_modules/jsdom/lib/jsdom/browser/Window.js:32
  this._globalProxy = vm.runInContext("this", this);
                         ^
TypeError: needs a 'context' argument.
    at new Window (/home/ubuntu/src/.../node_modules/newman/node_modules/jsdom/lib/jsdom/browser/Window.js:32:26)
    at Object.exports.jsdom (/home/ubuntu/src/.../node_modules/newman/node_modules/jsdom/lib/jsdom.js:46:16)
    at processHTML (/home/ubuntu/src/.../node_modules/newman/node_modules/jsdom/lib/jsdom.js:220:24)
    at /home/ubuntu/src/.../node_modules/newman/node_modules/jsdom/lib/jsdom.js:140:13
    at fs.js:207:20
    at Object.oncomplete (fs.js:107:15)
```