### PR TITLE
Add options to dump environment and globals to files

### DIFF
--- a/bin/newman
+++ b/bin/newman
@@ -29,8 +29,10 @@ function parseArguments() {
 		.option('-u, --url [url]', 'Specify a Postman collection as a [url]', null)
 		.option('-f, --folder [folder-name]', 'Run a single folder from a collection. To be used with -c or -u', null)
 		.option('-e, --environment [file]', 'Specify a Postman environment as a JSON [file]', null)
+		.option('-E, --exportEnvironment [file]', 'Specify an output file to dump the Postman environment before exiting [file]', null)
 		.option('-d, --data [file]', 'Specify a data file to use either json or csv', null)
 		.option('-g, --global [file]', 'Specify a Postman globals file [file]', null)
+		.option('-G, --exportGlobals [file]', 'Specify an output file to dump Globals before exiting [file]', null)
 		.option('-y, --delay [number]', "Specify a delay (in ms) between requests", null)
 		.option('-s, --stopOnError', "Stops the runner with code=1 when a test case fails", null)
 		.option('-j, --noSummary', "Doesn't show the summary for each iteration", null)
@@ -159,6 +161,14 @@ function main() {
 		catch (err) {
 			Errors.terminateWithError("The global file " + program.global+" could not be parsed.");
 		}
+	}
+
+	if (program.exportGlobals) {
+		newmanOptions.exportGlobalsFile = program.exportGlobals;
+	}
+
+	if (program.exportEnvironment) {
+		newmanOptions.exportEnvironmentFile = program.exportEnvironment;
 	}
 
 	if (program.tls) {

--- a/src/Newman.js
+++ b/src/Newman.js
@@ -5,6 +5,8 @@ var jsface          = require("jsface"),
     EventEmitter     = require('./utilities/EventEmitter'),
     Globals          = require('./utilities/Globals'),
     Options          = require('./utilities/Options'),
+    log              = require('./utilities/Logger'),
+    fs               = require('fs'),
     exec             = require('child_process').exec;
 
 /**
@@ -57,7 +59,19 @@ var Newman = jsface.Class([Options, EventEmitter], {
         this.setOptions(options);
 
         if (typeof callback === "function") {
-            this.addEventListener('iterationRunnerOver', callback);
+            this.addEventListener('iterationRunnerOver', function() {
+                if (options.exportGlobalsFile) {
+                    fs.writeFileSync(options.exportGlobalsFile, JSON.stringify(Globals.globalJson.values,null,1));
+                    log.note("\n\nGlobals File Exported To: " + options.exportGlobalsFile + "\n");
+                }
+
+                if (options.exportEnvironmentFile) {
+                    fs.writeFileSync(options.exportEnvironmentFile, JSON.stringify(Globals.envJson,null,1));
+                    log.note("\n\nEnvironment File Exported To: " + options.exportEnvironmentFile + "\n");
+                }
+
+                callback();
+            });
         }
 
         // setup the iteration runner with requestJSON passed and options


### PR DESCRIPTION
Add options to dump environment and globals(or environment) variables before newman exits to a file.

This allows the user to capture state of the environment and globals after a run for future reference (or use in subsequent invocations of newman or postman).